### PR TITLE
support for native classList

### DIFF
--- a/$dom.dev.js
+++ b/$dom.dev.js
@@ -490,7 +490,11 @@
     }
 
     function _hasClass(elm, className) {
-        return (" " + elm.className + " ").indexOf(" "+className+" ") > -1;
+        if (elm.hasOwnProperty("classList")) {
+            return elm.classList.contains("className")
+        } else {
+            return (" " + elm.className + " ").indexOf(" "+className+" ") > -1;
+        }
     }
 
     function _addClass(elm, className) {

--- a/$dom.dev.js
+++ b/$dom.dev.js
@@ -499,13 +499,21 @@
 
     function _addClass(elm, className) {
         if (!_hasClass(elm, className)) {
-            elm.className += " " + className;
+            if (elm.hasOwnProperty("classList")) {
+                elm.classList.add(className);
+            } else { 
+                elm.className += " " + className;
+            }
         }
     }
 
     function _removeClass(elm, className) {
         if (_hasClass(elm, className)) {
-            elm.className = elm.className.replace(new RegExp("(^|\\s)" + className + "(\\s|$)"), " ").replace(/\s$/, "");
+            if (elm.hasOwnProperty("classList")) {
+                elm.classList.remove(className);
+            } else { 
+                elm.className = elm.className.replace(new RegExp("(^|\\s)" + className + "(\\s|$)"), " ").replace(/\s$/, "");
+            }
         }
     }
 
@@ -553,4 +561,3 @@
     init();
 
 })(this);
-


### PR DESCRIPTION
I've modified `_hasClass()`, `_addClass()` and `_removeClass` to use the native method `classList` in browsers that support it.
I've made a small testcase at http://jsperf.com/element-classlist-vs-element-classname/ that shows that this method works faster than using `indexOf`on the `className`.
